### PR TITLE
Split the npm command to three runs allows to debug when the docker build is going wrong

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ FROM ${nodeImage} AS web
 WORKDIR ${APP_ROOT}
 COPY --chown=${USER} ./web .
 
-RUN npm ci && \
-    npm run build && \
-    npm test --  --runInBand --coverage --watchAll=false
+RUN npm ci 
+RUN npm run build 
+RUN npm test --  --runInBand --coverage --watchAll=false
 
 FROM ${buildImage} AS build
 


### PR DESCRIPTION
Split the npm command to three runs allows to debug when the doc…ker build is going wrong